### PR TITLE
Fix floodmap

### DIFF
--- a/cht_tiling/__init__.py
+++ b/cht_tiling/__init__.py
@@ -7,7 +7,7 @@ Created on Sun Apr 25 10:58:08 2021
 
 __version__ = "0.1.2"
 
-from cht_tiling.tiled_web_map import TiledWebMap
 from cht_tiling.flood_map import FloodMap
+from cht_tiling.tiled_web_map import TiledWebMap
 
 __all__ = ["TiledWebMap"]

--- a/cht_tiling/flood_map.py
+++ b/cht_tiling/flood_map.py
@@ -1,21 +1,22 @@
 import os
-from PIL import Image
-from typing import Union
-import xarray as xr
-import numpy as np
-import rioxarray
-import rasterio
 from pathlib import Path
+from typing import Union
+
+import contextily as ctx
 import matplotlib.pyplot as plt
+import numpy as np
+import rasterio
+import rioxarray
+import xarray as xr
 from matplotlib import cm
+from matplotlib.colors import BoundaryNorm, ListedColormap
+from matplotlib.patches import Patch
+from PIL import Image
 from pyproj import Transformer
-from rasterio.warp import calculate_default_transform, reproject, Resampling
+from rasterio.warp import Resampling, calculate_default_transform, reproject
 
 # from rasterio.enums import Resampling as RioResampling
 from rasterio.windows import from_bounds
-from matplotlib.colors import ListedColormap, BoundaryNorm
-from matplotlib.patches import Patch
-import contextily as ctx
 
 import cht_tiling.fileops as fo
 from cht_tiling.utils import deg2num, num2deg, png2elevation, png2int
@@ -234,7 +235,6 @@ class FloodMap:
         elif output_file.endswith(".tif"):
             # Write to geotiff
             if self.cmap is not None:
-
                 # Get RBG data array
                 rgb_da = get_rgb_data_array(
                     self.ds[self.data_array_name],
@@ -271,7 +271,6 @@ class FloodMap:
             return
 
         try:
-
             # Get the bounds of the data
             lon_min = xlim[0]
             lat_min = ylim[0]
@@ -414,7 +413,6 @@ class FloodMap:
         fig, ax = plt.subplots(figsize=(width, aspect_ratio * width))
 
         if discrete_colors:
-
             masked = da_3857.where(da_3857 >= color_values[0]["lower_value"])
 
             classified = xr.full_like(masked, np.nan)
@@ -430,7 +428,7 @@ class FloodMap:
                     labels.append(f"{lv}–{uv} m")
                 else:
                     lv = color_value["lower_value"]
-                    classified = classified.where(~((masked > lv)), icolor + 1)
+                    classified = classified.where(~(masked > lv), icolor + 1)
                     labels.append(f">{lv} m")
                 colors.append(color_value["color"])
 
@@ -454,7 +452,6 @@ class FloodMap:
             plt.legend(handles=legend_elements, title="Flood Depth", loc="lower right")
 
         else:
-
             # Plot the water depth
             da_3857.plot(
                 ax=ax,
@@ -616,7 +613,6 @@ def get_rgb_data_array(
 
 
 def reproject_bbox(xmin, ymin, xmax, ymax, crs_src, crs_dst, buffer=0.0):
-
     transformer = Transformer.from_crs(crs_src, crs_dst, always_xy=True)
 
     # Buffer the bounding box
@@ -689,12 +685,12 @@ def make_flood_map_tiles(
 
     # First do highest zoom level, then derefine from there
     if not zoom_range:
-        # Check available levels in index tiles
-        levs = fo.list_folders(os.path.join(index_path, "*"), basename=True)
-        zoom_range = [999, -999]
-        for lev in levs:
-            zoom_range[0] = min(zoom_range[0], int(lev))
-            zoom_range[1] = max(zoom_range[1], int(lev))
+        zoom_range = [0, 23]
+    # Check available levels in index tiles, if zoom_range is set too large, change accordingly
+    levs = fo.list_folders(os.path.join(index_path, "*"), basename=True)
+    levs_sorted = sorted(levs, key=lambda x: int(x))
+    zoom_range[0] = max(zoom_range[0], int(levs_sorted[0]))
+    zoom_range[1] = min(zoom_range[1], int(levs_sorted[-1]))
 
     izoom = zoom_range[1]
 

--- a/cht_tiling/tiled_web_map.py
+++ b/cht_tiling/tiled_web_map.py
@@ -250,11 +250,13 @@ class TiledWebMap:
                 else:
                     # Find appropriate zoom level
                     zoom_max = get_zoom_level_for_resolution(dx_max_zoom)
-                zoom_range = [0, zoom_max]    
+                zoom_range = [0, zoom_max]
 
-            # Now loop through datasets in data_list 
+            # Now loop through datasets in data_list
             for idata, data_dict in enumerate(data_list):
-                print(f"Processing {data_dict['name']} ... ({idata + 1} of {len(data_list)})")
+                print(
+                    f"Processing {data_dict['name']} ... ({idata + 1} of {len(data_list)})"
+                )
                 make_topobathy_tiles_top_level(
                     self,
                     data_dict,

--- a/cht_tiling/tiling.py
+++ b/cht_tiling/tiling.py
@@ -170,6 +170,22 @@ def make_png_tiles(
 
                     valt = zb
 
+                elif option == "water_level":
+                    valt = valg[ind]
+                    valt[np.where(ind < 0)] = np.nan
+
+                    if topo_path is not None:
+                        # Read bathy
+                        bathy_file = os.path.join(
+                            topo_path, str(izoom), ifolder, str(j) + ".dat"
+                        )
+                        if not os.path.exists(bathy_file):
+                            # No bathy for this tile, continue
+                            continue
+                        zb = np.fromfile(bathy_file, dtype="f4")
+                        # only show water levels for bed levels below zbmax (i.e. wet areas)
+                        valt[zb > zbmax] = np.nan
+
                 else:
                     valt = valg[ind]
                     valt[ind < 0] = np.nan
@@ -268,12 +284,12 @@ def make_floodmap_tiles(
 
     # First do highest zoom level, then derefine from there
     if not zoom_range:
-        # Check available levels in index tiles
-        levs = fo.list_folders(os.path.join(index_path, "*"), basename=True)
-        zoom_range = [999, -999]
-        for lev in levs:
-            zoom_range[0] = min(zoom_range[0], int(lev))
-            zoom_range[1] = max(zoom_range[1], int(lev))
+        zoom_range = [0, 23]
+    # Check available levels in index tiles, if zoom_range is set too large, change accordingly
+    levs = fo.list_folders(os.path.join(index_path, "*"), basename=True)
+    levs_sorted = sorted(levs, key=lambda x: int(x))
+    zoom_range[0] = max(zoom_range[0], int(levs_sorted[0]))
+    zoom_range[1] = min(zoom_range[1], int(levs_sorted[-1]))
 
     izoom = zoom_range[1]
 

--- a/cht_tiling/tiling.py
+++ b/cht_tiling/tiling.py
@@ -18,7 +18,7 @@ from pyproj import CRS, Transformer
 from scipy.interpolate import RegularGridInterpolator
 
 import cht_tiling.fileops as fo
-from cht_tiling.utils import deg2num, num2deg, png2elevation, png2int
+from cht_tiling.utils import deg2num, num2deg, png2elevation, elevation2png, png2int, int2png
 
 # class TileLayerTime:
 #     def __init__(self):
@@ -1310,29 +1310,29 @@ def num2deg_ur(xtile, ytile, zoom):
 # Note: we only use the RGB channels for this (and not the alpha channel)
 
 
-def png2elevation(png_file):
-    """Convert png to elevation array based on terrarium interpretation"""
-    img = Image.open(png_file)
-    rgb = np.array(img.convert("RGB"))
-    # Convert RGB values to elevation values
-    elevation = (rgb[:, :, 0] * 256 + rgb[:, :, 1] + rgb[:, :, 2] / 256) - 32768.0
-    # where val is less than -32767, set to NaN
-    elevation[elevation < -32767.0] = np.nan
-    return elevation
+# def png2elevation(png_file):
+#     """Convert png to elevation array based on terrarium interpretation"""
+#     img = Image.open(png_file)
+#     rgb = np.array(img.convert("RGB"))
+#     # Convert RGB values to elevation values
+#     elevation = (rgb[:, :, 0] * 256 + rgb[:, :, 1] + rgb[:, :, 2] / 256) - 32768.0
+#     # where val is less than -32767, set to NaN
+#     elevation[elevation < -32767.0] = np.nan
+#     return elevation
 
 
-def elevation2png(val, png_file):
-    """Convert elevation array to png using terrarium interpretation"""
-    rgb = np.zeros((256 * 256, 3), "uint8")
-    # r, g, b = elevation2rgb(val)
-    val += 32768.0
-    rgb[:, 0] = np.floor(val / 256).flatten()
-    rgb[:, 1] = np.floor(val % 256).flatten()
-    rgb[:, 2] = np.floor((val - np.floor(val)) * 256).flatten()
-    rgb = rgb.reshape([256, 256, 3])
-    # Create PIL Image from RGB values and save as PNG
-    img = Image.fromarray(rgb)
-    img.save(png_file)
+# def elevation2png(val, png_file):
+#     """Convert elevation array to png using terrarium interpretation"""
+#     rgb = np.zeros((256 * 256, 3), "uint8")
+#     # r, g, b = elevation2rgb(val)
+#     val += 32768.0
+#     rgb[:, 0] = np.floor(val / 256).flatten()
+#     rgb[:, 1] = np.floor(val % 256).flatten()
+#     rgb[:, 2] = np.floor((val - np.floor(val)) * 256).flatten()
+#     rgb = rgb.reshape([256, 256, 3])
+#     # Create PIL Image from RGB values and save as PNG
+#     img = Image.fromarray(rgb)
+#     img.save(png_file)
 
 
 # def elevation2rgb(val):
@@ -1372,21 +1372,21 @@ def elevation2png(val, png_file):
 #     )
 
 
-def int2png(val, png_file):
-    """Convert int array to png"""
-    # Convert index integers to RGBA values
-    rgba = np.zeros((256, 256, 4), "uint8")
-    r = (val // 256**3) % 256
-    g = (val // 256**2) % 256
-    b = (val // 256) % 256
-    a = val % 256
-    rgba[:, :, 0] = r.flatten()
-    rgba[:, :, 1] = g.flatten()
-    rgba[:, :, 2] = b.flatten()
-    rgba[:, :, 3] = a.flatten()
-    # Create PIL Image from RGB values and save as PNG
-    img = Image.fromarray(rgba)
-    img.save(png_file)
+# def int2png(val, png_file):
+#     """Convert int array to png"""
+#     # Convert index integers to RGBA values
+#     rgba = np.zeros((256, 256, 4), "uint8")
+#     r = (val // 256**3) % 256
+#     g = (val // 256**2) % 256
+#     b = (val // 256) % 256
+#     a = val % 256
+#     rgba[:, :, 0] = r.flatten()
+#     rgba[:, :, 1] = g.flatten()
+#     rgba[:, :, 2] = b.flatten()
+#     rgba[:, :, 3] = a.flatten()
+#     # Create PIL Image from RGB values and save as PNG
+#     img = Image.fromarray(rgba)
+#     img.save(png_file)
 
 
 # def int2rgba(int_val):

--- a/cht_tiling/topobathy.py
+++ b/cht_tiling/topobathy.py
@@ -62,9 +62,7 @@ def make_topobathy_tiles_top_level(
         zoom_range = [0, zoom_max]
     elif zoom_range is None:
         # Give error
-        raise ValueError(
-            "zoom_range must be provided if index_path is not provided"
-        )
+        raise ValueError("zoom_range must be provided if index_path is not provided")
 
     # transformer_3857_to_crs = Transformer.from_crs(
     #     CRS.from_epsg(3857), crs_data, always_xy=True
@@ -110,7 +108,9 @@ def make_topobathy_tiles_top_level(
     else:
         if lon_range is None or lat_range is None:
             # Get the lon_range and lat_range from the data_dict (should add this functionality to bathymetry_database)
-            lon_range, lat_range = bathymetry_database.get_lon_lat_range(data_dict["name"])
+            lon_range, lat_range = bathymetry_database.get_lon_lat_range(
+                data_dict["name"]
+            )
 
         ix0, iy0 = deg2num(lat_range[1], lon_range[0], izoom)
         ix1, iy1 = deg2num(lat_range[0], lon_range[1], izoom)
@@ -299,9 +299,7 @@ def bbox_xy2latlon(x0, x1, y0, y1, crs):
     return lon_min, lon_max, lat_min, lat_max
 
 
-def create_highest_zoom_level_tile(
-    zoom_path_i, i, j, izoom, twm, data_dict, options        
-):
+def create_highest_zoom_level_tile(zoom_path_i, i, j, izoom, twm, data_dict, options):
     file_name = os.path.join(zoom_path_i, str(j) + ".png")
     transformer_4326_to_3857 = options["transformer_4326_to_3857"]
     # transformer_3857_to_crs = options["transformer_3857_to_crs"]

--- a/cht_tiling/utils.py
+++ b/cht_tiling/utils.py
@@ -412,7 +412,7 @@ def png2int(png_file, idummy):
         + rgba[:, :, 3]
     )
     ind[np.where(ind == 4294967295)] = idummy
-    return ind
+    return np.flip(ind, axis=0)
 
 
 def int2png(val, png_file):


### PR DESCRIPTION
In CoSMoS often default values were provided for zoom_range, for example [0,14]. However, when the finest zoom level in this case does not exist, no floodmaps will be made. Therefore I guess it makes more sense to take into account which zoom-levels are present and change the zoom_range accordingly.

Also the water_level option for png-tiles was absent, in which we would like to be able to "remove" water levels that are on land to make visualization more appealing.