### PR TITLE
fixes for floodmap

### DIFF
--- a/cht_tiling/data_tiles.py
+++ b/cht_tiling/data_tiles.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import Any
 
 import numpy as np
 
 from cht_tiling.utils import elevation2png, list_files, list_folders, makedir, png2int
+
+logger = logging.getLogger(__name__)
 
 
 def make_data_tiles(twm: Any) -> None:
@@ -42,7 +45,7 @@ def make_data_tiles(twm: Any) -> None:
 
     for izoom in range(twm.zoom_range[0], twm.zoom_range[1] + 1):
         if not twm.quiet:
-            print(f"Processing zoom level {izoom}")
+            logger.info(f"Processing zoom level {izoom}")
 
         index_zoom_path = os.path.join(twm.index_path, str(izoom))
 

--- a/cht_tiling/fileops.py
+++ b/cht_tiling/fileops.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import glob
 import os
 import shutil
+import logging
 
+logger = logging.getLogger(__name__)
 
 def move_file(src: str, dst: str) -> None:
     """Move files matching a glob pattern to a destination directory.
@@ -23,11 +25,11 @@ def move_file(src: str, dst: str) -> None:
             try:
                 os.remove(os.path.join(dst, src_name))
             except Exception:
-                print(f"Could not remove file {os.path.join(dst, src_name)}")
+                logger.error(f"Could not remove file {os.path.join(dst, src_name)}")
         try:
             shutil.move(full_file_name, dst)
         except Exception:
-            print(f"Could not move file {full_file_name}")
+            logger.error(f"Could not move file {full_file_name}")
 
 
 def copy_file(src: str, dst: str) -> None:
@@ -63,7 +65,7 @@ def delete_file(src: str) -> None:
         try:
             os.remove(src)
         except Exception:
-            print(f"Could not delete {src}")
+            logger.error(f"Could not delete {src}")
 
 
 def rm(src: str) -> None:
@@ -154,7 +156,7 @@ def delete_folder(src: str) -> None:
     try:
         shutil.rmtree(src, ignore_errors=False, onerror=None)
     except Exception:
-        print(f"Could not delete folder {src}")
+        logger.error(f"Could not delete folder {src}")
 
 
 def rmdir(src: str) -> None:
@@ -169,7 +171,7 @@ def rmdir(src: str) -> None:
         if os.path.exists(src):
             shutil.rmtree(src, ignore_errors=False, onerror=None)
     except Exception:
-        print(f"Could not delete folder {src}")
+        logger.error(f"Could not delete folder {src}")
 
 
 def exists(src: str) -> bool:

--- a/cht_tiling/fileops.py
+++ b/cht_tiling/fileops.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import glob
+import logging
 import os
 import shutil
-import logging
 
 logger = logging.getLogger(__name__)
+
 
 def move_file(src: str, dst: str) -> None:
     """Move files matching a glob pattern to a destination directory.

--- a/cht_tiling/flood_map.py
+++ b/cht_tiling/flood_map.py
@@ -7,6 +7,7 @@ shared utilities for overview level selection, RGB conversion, and bounding
 box reprojection.
 """
 
+import logging
 import os
 from pathlib import Path
 
@@ -25,6 +26,8 @@ from rasterio.warp import Resampling
 
 import cht_tiling.fileops as fo
 from cht_tiling.utils import deg2num, num2deg, png2elevation, png2int
+
+logger = logging.getLogger(__name__)
 
 
 class FloodMap:
@@ -317,7 +320,10 @@ class FloodMap:
             True on success, False on failure.
         """
         if self.ds is None:
-            return
+            logger.error(
+                "Dataset is not initialized. Call make() or read() before map_overlay()."
+            )
+            return False
 
         try:
             lon_min = xlim[0]
@@ -415,6 +421,7 @@ class FloodMap:
             return True
 
         except Exception as e:
+            logger.exception(e)
             return False
 
     def plot(
@@ -841,7 +848,7 @@ def make_flood_map_tiles(
     izoom = zoom_range[1]
 
     if not quiet:
-        print(f"Processing zoom level {izoom}")
+        logger.info(f"Processing zoom level {izoom}")
 
     index_zoom_path = os.path.join(index_path, str(izoom))
 
@@ -934,7 +941,7 @@ def make_flood_map_tiles(
 
     for izoom in range(zoom_range[1] - 1, zoom_range[0] - 1, -1):
         if not quiet:
-            print(f"Processing zoom level {izoom}")
+            logger.info(f"Processing zoom level {izoom}")
 
         index_zoom_path = os.path.join(index_path, str(izoom))
 
@@ -1082,8 +1089,7 @@ def make_flood_map_overlay_v2(
     """
     try:
         if isinstance(valg, list):
-            print("valg is a list!")
-            pass
+            logger.info("valg is a list!")
         elif isinstance(valg, xr.DataArray):
             valg = valg.to_numpy()
             if mean_depth is not None:
@@ -1121,7 +1127,7 @@ def make_flood_map_overlay_v2(
         zz[:] = np.nan
 
         if not quiet:
-            print(f"Processing zoom level {izoom}")
+            logger.info(f"Processing zoom level {izoom}")
 
         index_zoom_path = os.path.join(index_path, str(izoom))
 
@@ -1212,6 +1218,5 @@ def make_flood_map_overlay_v2(
         return [lon0, lon1], [lat0, lat1], caxis
 
     except Exception as e:
-        print(e)
-        traceback.print_exc()
+        logger.exception(e)
         return None, None

--- a/cht_tiling/flood_map.py
+++ b/cht_tiling/flood_map.py
@@ -80,17 +80,22 @@ class FloodMap:
         self.index_file = None
         self.zb = None
         self.indices = None
-        self.zbmin = 0.0
-        self.zbmax = 99999.9
-        self.hmin = 0.1
-        self.max_pixel_size = 0.0
-        self.data_array_name = "water_depth"
-        self.color_values = "default"
-        self.cmap = "jet"
-        self.cmin = 0.0
-        self.cmax = 1.0
-        self.discrete_colors = False
+        self.zbmin = zbmin
+        self.zbmax = zbmax
+        self.hmin = hmin
+        self.max_pixel_size = max_pixel_size
+        self.data_array_name = data_array_name
+        self.color_values = color_values if color_values is not None else "default"
+        self.cmap = cmap if cmap is not None else "jet"
+        self.cmin = cmin if cmin is not None else 0.0
+        self.cmax = cmax if cmax is not None else 1.0
+        self.discrete_colors = color_values is not None
         self.ds = xr.Dataset()
+
+        if topobathy_file is not None:
+            self.set_topobathy_file(topobathy_file)
+        if index_file is not None:
+            self.set_index_file(index_file)
 
         self.legend = {}
         self.legend["title"] = "Flood Depth (m)"
@@ -648,10 +653,9 @@ def get_rgb_data_array(
     xr.DataArray
         RGBA DataArray with shape ``(4, height, width)`` and dtype uint8.
     """
+    ny, nx = da.shape
     if color_values is not None:
-        ny, nx = da.shape
         zz = da.to_numpy()
-        rgba = np.zeros((ny, nx, 4), "uint8")
 
     if discrete_colors:
         if isinstance(color_values, str):
@@ -667,26 +671,22 @@ def get_rgb_data_array(
             )
             color_values.append({"color": "red", "lower_value": 2.0})
 
-        rgba = np.zeros((da.shape[0], da.shape[1], 4), dtype=np.float32)
-        for icolor, color_value in enumerate(color_values):
-            color_rgba = cm.colors.to_rgba(color_value["color"])
-            if "lower_value" in color_values and "upper_value" in color_value:
-                rgba[
-                    (da >= color_value["lower_value"])
-                    & (da < color_value["upper_value"]),
-                    :,
-                ] = color_rgba
-            elif "lower_value" in color_value:
-                rgba[(da >= color_value["lower_value"]), :] = color_rgba
-            elif "upper_value" in color_value:
-                rgba[(da < color_value["upper_value"]), :] = color_rgba
-            pass
-
-            # Mask out NaN values in zz
+        rgba = np.zeros((ny, nx, 4), "uint8")
+        for color_value in color_values:
+            lower = color_value.get("lower_value", -np.inf)
+            upper = color_value.get("upper_value", np.inf)
+            inr = np.logical_and(zz >= lower, zz < upper)
             valid = np.logical_and(inr, ~np.isnan(zz))
-            rgba[valid, 0] = color_value["rgb"][0]
-            rgba[valid, 1] = color_value["rgb"][1]
-            rgba[valid, 2] = color_value["rgb"][2]
+
+            if "rgb" in color_value:
+                rgba[valid, 0] = color_value["rgb"][0]
+                rgba[valid, 1] = color_value["rgb"][1]
+                rgba[valid, 2] = color_value["rgb"][2]
+            elif "color" in color_value:
+                color_rgba = cm.colors.to_rgba(color_value["color"])
+                rgba[valid, 0] = int(color_rgba[0] * 255)
+                rgba[valid, 1] = int(color_rgba[1] * 255)
+                rgba[valid, 2] = int(color_rgba[2] * 255)
             rgba[valid, 3] = 255
 
     else:

--- a/cht_tiling/index_tiles.py
+++ b/cht_tiling/index_tiles.py
@@ -203,7 +203,7 @@ def make_index_tiles_quadtree(
                             )
                             indx[incell[0], incell[1]] = cell_indices
                         except Exception:
-                            pass
+                            logger.error("Error in binary search for cell indices")
 
                 if np.any(indx >= 0):
                     if not path_okay:

--- a/cht_tiling/index_tiles.py
+++ b/cht_tiling/index_tiles.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import math
 import os
 from typing import Any
@@ -17,6 +18,8 @@ from cht_tiling.utils import (
     num2deg,
     png2elevation,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def make_index_tiles(twm: Any, topo_path: str | None = None) -> None:
@@ -131,7 +134,7 @@ def make_index_tiles_quadtree(
         nm_lev.append(mm * nmax_lev[level] + nn)
 
     for izoom in range(zoom_range[0], zoom_range[1] + 1):
-        print(f"Processing zoom level {izoom}")
+        logger.info(f"Processing zoom level {izoom}")
 
         zoom_path = os.path.join(path, str(izoom))
 

--- a/cht_tiling/rgba_tiles.py
+++ b/cht_tiling/rgba_tiles.py
@@ -4,6 +4,7 @@ Supports flood maps, water level maps, topography, and direct value rendering
 with either discrete color ranges or continuous colormap scaling.
 """
 
+import logging
 import os
 
 import numpy as np
@@ -11,6 +12,8 @@ from matplotlib import cm
 from PIL import Image
 
 from cht_tiling.utils import list_files, list_folders, makedir, png2elevation, png2int
+
+logger = logging.getLogger(__name__)
 
 
 def make_rgba_tiles(twm: object) -> None:
@@ -89,7 +92,7 @@ def make_rgba_tiles(twm: object) -> None:
 
     for izoom in range(twm.zoom_range[0], twm.zoom_range[1] + 1):
         if not twm.quiet:
-            print(f"Processing zoom level {izoom}")
+            logger.info(f"Processing zoom level {izoom}")
 
         index_zoom_path = os.path.join(twm.index_path, str(izoom))
 

--- a/cht_tiling/tiled_web_map.py
+++ b/cht_tiling/tiled_web_map.py
@@ -5,6 +5,7 @@ slippy-map tile pyramids with support for various encoders (terrarium, mapbox)
 and tile types (elevation data, RGBA imagery, index tiles).
 """
 
+import logging
 import os
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
@@ -32,9 +33,9 @@ from cht_tiling.utils import (
     xy2num,
 )
 from cht_tiling.webviewer import write_html
-import logging
 
 logger = logging.getLogger(__name__)
+
 
 class ZoomLevel:
     """Container for tile availability data at a single zoom level.

--- a/cht_tiling/tiled_web_map.py
+++ b/cht_tiling/tiled_web_map.py
@@ -32,7 +32,9 @@ from cht_tiling.utils import (
     xy2num,
 )
 from cht_tiling.webviewer import write_html
+import logging
 
+logger = logging.getLogger(__name__)
 
 class ZoomLevel:
     """Container for tile availability data at a single zoom level.
@@ -368,7 +370,7 @@ class TiledWebMap:
                 if self.make_highest_level:
                     # Now loop through datasets in data_list (if zoom range is none and there is an index_path, it is set here)
                     for idata, data_dict in enumerate(self.data):
-                        print(
+                        logger.info(
                             f"Processing {data_dict['name']} ... ({idata + 1} of {len(self.data)})"
                         )
                         make_topobathy_tiles_top_level(
@@ -501,10 +503,10 @@ class TiledWebMap:
                 Key=key,
                 Filename=filename,
             )
-            print(f"Downloaded {key}")
+            logger.info(f"Downloaded {key}")
             okay = True
         except Exception:
-            print(f"Failed to download {key}")
+            logger.error(f"Failed to download {key}")
             okay = False
         return okay
 
@@ -535,12 +537,12 @@ class TiledWebMap:
                 Key=key,
                 Filename=file,
             )
-            print(f"Downloaded {key}")
+            logger.info(f"Downloaded {key}")
             okay = True
 
         except Exception as e:
-            print(e)
-            print(f"Failed to download {key}")
+            logger.exception(e)
+            logger.error(f"Failed to download {key}")
             okay = False
 
         return okay
@@ -586,7 +588,7 @@ class TiledWebMap:
                 quiet=quiet,
             )
         except Exception:
-            print("An error occurred while uploading !")
+            logger.error("An error occurred while uploading !")
 
     def write_availability_file(self) -> None:
         """Write tile availability to ``available_tiles.nc``."""

--- a/cht_tiling/topobathy_map.py
+++ b/cht_tiling/topobathy_map.py
@@ -5,6 +5,7 @@ maps, writing output files (GeoTIFF/NetCDF), creating map overlays, and
 plotting with matplotlib.
 """
 
+import logging
 from pathlib import Path
 
 import contextily as ctx
@@ -23,9 +24,9 @@ from cht_tiling.flood_map import (
     get_rgb_data_array,
     reproject_bbox,
 )
-import logging
 
 logger = logging.getLogger(__name__)
+
 
 class TopoBathyMap:
     """Manages reading, processing, and visualising topography/bathymetry data.

--- a/cht_tiling/topobathy_map.py
+++ b/cht_tiling/topobathy_map.py
@@ -23,7 +23,9 @@ from cht_tiling.flood_map import (
     get_rgb_data_array,
     reproject_bbox,
 )
+import logging
 
+logger = logging.getLogger(__name__)
 
 class TopoBathyMap:
     """Manages reading, processing, and visualising topography/bathymetry data.
@@ -288,7 +290,7 @@ class TopoBathyMap:
             return True
 
         except Exception as e:
-            print(f"Error in map_overlay: {e}")
+            logger.exception(f"Error in map_overlay: {e}")
             return False
 
     def plot(

--- a/cht_tiling/topobathy_tiles.py
+++ b/cht_tiling/topobathy_tiles.py
@@ -354,7 +354,9 @@ def create_highest_zoom_level_tile(
             da = data_catalog.get_rasterdataset(name, geom=geom, zoom=(dxy, "metre"))
             zg = da.values.astype(np.float64)
         except Exception:
-            logger.error(f"Could not fetch data for tile {i}/{j} at zoom level {izoom}. Falling back to NaN.")
+            logger.error(
+                f"Could not fetch data for tile {i}/{j} at zoom level {izoom}. Falling back to NaN."
+            )
             zg = np.full((len(y3857), len(x3857)), np.nan)
     else:
         zg = np.full(x3857.shape, np.nan)

--- a/cht_tiling/topobathy_tiles.py
+++ b/cht_tiling/topobathy_tiles.py
@@ -354,6 +354,7 @@ def create_highest_zoom_level_tile(
             da = data_catalog.get_rasterdataset(name, geom=geom, zoom=(dxy, "metre"))
             zg = da.values.astype(np.float64)
         except Exception:
+            logger.error(f"Could not fetch data for tile {i}/{j} at zoom level {izoom}. Falling back to NaN.")
             zg = np.full((len(y3857), len(x3857)), np.nan)
     else:
         zg = np.full(x3857.shape, np.nan)

--- a/cht_tiling/topobathy_tiles.py
+++ b/cht_tiling/topobathy_tiles.py
@@ -112,7 +112,7 @@ def make_topobathy_tiles_top_level(twm: object, data_dict: dict) -> None:
 
     # Loop in x direction
     for i in range(ix0, ix1 + 1):
-        print(f"Processing column {i - ix0 + 1} of {ix1 - ix0 + 1}")
+        logger.info(f"Processing column {i - ix0 + 1} of {ix1 - ix0 + 1}")
 
         zoom_path_i = os.path.join(zoom_path, str(i))
 
@@ -149,7 +149,7 @@ def make_topobathy_tiles_top_level(twm: object, data_dict: dict) -> None:
 
     t1 = time.time()
 
-    print(f"Elapsed time for zoom level {izoom}: {t1 - t0}")
+    logger.info(f"Elapsed time for zoom level {izoom}: {t1 - t0}")
 
 
 def make_topobathy_tiles_lower_levels(twm: object) -> None:
@@ -167,7 +167,7 @@ def make_topobathy_tiles_lower_levels(twm: object) -> None:
     npix = 256
 
     for izoom in range(twm.zoom_range[1] - 1, twm.zoom_range[0] - 1, -1):
-        print(f"Processing zoom level {izoom}")
+        logger.info(f"Processing zoom level {izoom}")
 
         t0 = time.time()
 
@@ -229,7 +229,7 @@ def make_topobathy_tiles_lower_levels(twm: object) -> None:
 
         t1 = time.time()
 
-        print(f"Elapsed time for zoom level {izoom}: {t1 - t0}")
+        logger.info(f"Elapsed time for zoom level {izoom}: {t1 - t0}")
 
 
 def bbox_xy2latlon(


### PR DESCRIPTION
fixes constructor of `FloodMap` to actually use the provided values.
fixes `get_rgb_data_array` 
replace all `print` with logging like in guitares.

Users can add something like this to their sciprts / apps to enable the logging of any package
```python
import logging

# this enables output to the console
logging.basicConfig() 

# set minimum level the cht_tiling logger and all its children. 
logger = logging.getLogger("cht_tiling").setLevel(logging.INFO)
```